### PR TITLE
Utilise network Docker « mss-network »

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,1 @@
-URL_SERVEUR_BASE_DONNEES= # URL du serveur de base de données, ex. postgres://user@db/mss-journal
+URL_SERVEUR_BASE_DONNEES= # URL du serveur de base de données, ex. postgres://user@mss-journal-db/mss-journal

--- a/README.md
+++ b/README.md
@@ -35,10 +35,19 @@ Créer la base de données `mss-journal` et un utilisateur `metabase`
 qui sera utilisé par Metabase.
 
 ```sh
-$ docker compose up db
-$ docker compose exec db createdb -U postgres mss-journal
-$ docker compose exec db createuser -U postgres metabase
+$ docker compose up mss-journal-db
+$ docker compose exec mss-journal-db createdb -U postgres mss-journal
+$ docker compose exec mss-journal-db createuser -U postgres metabase
 ```
+
+Vérifier la présence du `network` Docker `mss-network`.
+
+```sh
+$ docker network ls | grep mss-network
+```
+
+Cette commande devrait montrer le réseau `mss-network`. Si ce n'est pas le cas, se référer au `README` de
+[MonServiceSécurisé](https://github.com/betagouv/mon-service-securise) pour la création de celui-ci.
 
 Créer un fichier `.env` en copiant fichier `.env.template` puis valoriser chaque variable du `.env`.
 
@@ -51,8 +60,8 @@ $ docker compose up node
 Donner les droits en lecture sur les éléments créés à l'utilisateur `metabase`.
 
 ```sh
-$ docker compose exec db psql -U postgres -d mss-journal -c 'GRANT USAGE ON SCHEMA journal_mss TO metabase;'
-$ docker compose exec db psql -U postgres -d mss-journal -c 'GRANT SELECT ON ALL TABLES IN SCHEMA journal_mss TO metabase;'
+$ docker compose exec mss-journal-db psql -U postgres -d mss-journal -c 'GRANT USAGE ON SCHEMA journal_mss TO metabase;'
+$ docker compose exec mss-journal-db psql -U postgres -d mss-journal -c 'GRANT SELECT ON ALL TABLES IN SCHEMA journal_mss TO metabase;'
 ```
 
 
@@ -66,7 +75,7 @@ Accéder à Metabase en visitant http://localhost:3000/setup.
 
 Paramétrer Metabase en suivant les instructions à l'écran :
  - Base de données : PostgreSQL
- - Host : `db` (qui apparaît dans [./docker-compose.yml](./docker-compose.yml))
+ - Host : `mss-journal-db` (qui apparaît dans [./docker-compose.yml](./docker-compose.yml))
  - Port : `5432` (qui apparaît dans [./docker-compose.yml](./docker-compose.yml))
  - Database name : `mss-journal`
  - Username : `metabase`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 version: '3'
 
 services:
-  db:
+  mss-journal-db:
     image: postgres
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
     networks:
-      - postgres
+      - mss-network
     ports:
       - "5432:5432"
     volumes:
@@ -20,13 +20,13 @@ services:
       - MB_DB_PORT=5432
       - MB_DB_USER=metabase
       - MB_DB_PASS=
-      - MB_DB_HOST=db
+      - MB_DB_HOST=mss-journal-db
     networks:
-      - postgres
+      - mss-network
     ports:
       - "3000:3000"
     depends_on:
-      - db
+      - mss-journal-db
 
   # https://github.com/nodejs/docker-node/blob/main/README.md#how-to-use-this-image
   node:
@@ -36,9 +36,10 @@ services:
     working_dir: /home/node/app
     command: "./scripts/migrations.sh"
     networks:
-      - postgres
+      - mss-network
     depends_on:
-      - db
+      - mss-journal-db
 
 networks:
-  postgres:
+  mss-network:
+    external: true


### PR DESCRIPTION
Dans le cadre de la cohabitation avec mss, on veut un network nommé et 'external'. 

Pour que les conteneurs de mss-journal utilisent le même.

[La PR côté MSS](https://github.com/betagouv/mon-service-securise/pull/510)