### PR TITLE
Crée vue `journal_mss.vue_completude`

### DIFF
--- a/migrations/20230103094648_creationVueCompletude.js
+++ b/migrations/20230103094648_creationVueCompletude.js
@@ -1,0 +1,28 @@
+const vue = `journal_mss.vue_completude`;
+
+exports.up = knex => knex.raw(`CREATE OR REPLACE VIEW ${vue} AS 
+  
+WITH
+    evenements_plus_recents AS (
+        SELECT DISTINCT ON(donnees->>'idService')
+            id AS id_dernier_evenement
+        FROM journal_mss.evenements
+        WHERE type = 'COMPLETUDE_SERVICE_MODIFIEE'
+        ORDER BY donnees->>'idService', date DESC
+    ),
+    completude AS (
+        SELECT
+            id AS id_completude,
+            ((donnees->>'nombreMesuresCompletes')::FLOAT / (donnees->>'nombreTotalMesures')::FLOAT) * 100 AS completion
+        FROM journal_mss.evenements
+        WHERE type = 'COMPLETUDE_SERVICE_MODIFIEE'
+    )
+
+SELECT c.completion, e.donnees, e.date, e.id
+FROM evenements_plus_recents recents
+JOIN completude c ON recents.id_dernier_evenement = c.id_completude
+JOIN journal_mss.evenements e ON recents.id_dernier_evenement = e.id 
+
+;`);
+
+exports.down = knex => knex.raw(`DROP VIEW IF EXISTS ${vue};`)


### PR DESCRIPTION
### Besoin 

Dans Metabase nous voulons savoir le nombre de services qui ont atteint un certain niveau de complétude.
On veut une visualisation qui permettra de voir, par exemple :
```
Complétude entre 0 et 20% : 50 services
Complétude entre 20 et 50% : 23 services
Complétude supérieure à 50% : 145 services
```

### Contexte
Nous avons désormais des événements `'COMPLETUDE_SERVICE_MODIFIEE'` dans Metabase.
Côté MSS un événement est généré à chaque modification de complétude d'un service ➡️ [la PR côté MSS](https://github.com/betagouv/mon-service-securise/pull/584)


Les `donnees` JSON d'un événement `COMPLETUDE_SERVICE_MODIFIEE` sont :

```json
{
  "idService": "…",
  "nombreTotalMesures": 59, 
  "nombreMesuresCompletes": 21
}
```

La base de données Journal contient donc toutes les données brutes nécessaires au calcul de la visualisation voulue dans Metabase.

### PR
Cette PR ajoute une **vue SQL** permettant l'exploitation des données brutes des événements.

Je vous colle ici le code de la vue, avec coloration syntaxique :
```sql
WITH
    evenements_plus_recents AS (
        SELECT DISTINCT ON(donnees->>'idService')
            id AS id_dernier_evenement
        FROM journal_mss.evenements
        WHERE type = 'COMPLETUDE_SERVICE_MODIFIEE'
        ORDER BY donnees->>'idService', date DESC
    ),
    completude AS (
        SELECT
            id AS id_completude,
            ((donnees->>'nombreMesuresCompletes')::FLOAT / (donnees->>'nombreTotalMesures')::FLOAT) * 100 AS completion
        FROM journal_mss.evenements
        WHERE type = 'COMPLETUDE_SERVICE_MODIFIEE'
    )

SELECT c.completion, e.donnees, e.date, e.id
FROM evenements_plus_recents recents
JOIN completude c ON recents.id_dernier_evenement = c.id_completude
JOIN journal_mss.evenements e ON recents.id_dernier_evenement = e.id
```

Cette vue produit 1 ligne par service MSS. Cette ligne correspond à l'événement de complétude **le plus récent** pour le service.
Autrement dit : si en tant qu'utilisateur MSS j'ai modifié mon service lundi puis mardi puis mercredi, cette vue SQL ne retiendra que l'événement du mercredi.

Exemple de sortie… 

![image](https://user-images.githubusercontent.com/24898521/210341033-b7d39fb0-2c4a-45fe-b4ff-8fe7b959f2ba.png)

…lorsque la base de données contient les 5 événements…

![image](https://user-images.githubusercontent.com/24898521/210341266-f2882e79-e74f-4f34-bc02-12faaa371158.png)

### Côté Metabase
Une vois la vue SQL créée il reste à créer une **Question Metabase** qui l'utilise.

J'ai en tête que cette question Metabase sera formulée en SQL et utilisera des variables Metabase :

![image](https://user-images.githubusercontent.com/24898521/210341695-513ed8d6-dee7-4234-a39e-5540b2432464.png)
