### PR TITLE
Crée vue `journal_mss.vue_evenements_sans_services_supprimes`

### DIFF
--- a/migrations/20230110103305_creationVueEvenementsSansServicesSupprimes.js
+++ b/migrations/20230110103305_creationVueEvenementsSansServicesSupprimes.js
@@ -1,0 +1,16 @@
+const vue = `journal_mss.vue_evenements_sans_services_supprimes`;
+
+exports.up = knex => knex.raw(`CREATE OR REPLACE VIEW ${vue} AS 
+  
+SELECT *
+FROM journal_mss.evenements
+WHERE donnees->'idService' NOT IN (
+    SELECT donnees->'idService'
+    FROM journal_mss.evenements
+    WHERE type = 'SERVICE_SUPPRIME'
+)
+
+;`);
+
+
+exports.down = knex => knex.raw(`DROP VIEW IF EXISTS ${vue};`)


### PR DESCRIPTION
… pour les questions Metabase qui ont besoin de se brancher sur une source de données qui ne contient aucune information liée à des services supprimés.

Cette PR ajoute une vue dans laquelle tous les événements liés à un service supprimé sont filtrés.