### PR TITLE
Création de vues pour visualiser dans Metabase la répartition des statuts par mesure

### DIFF
--- a/migrations/20230203150906_creationVueStatutsMesuresPersonnalisees.js
+++ b/migrations/20230203150906_creationVueStatutsMesuresPersonnalisees.js
@@ -1,0 +1,28 @@
+const vue = `journal_mss.vue_statuts_mesures_personnalisees`;
+
+exports.up = knex => knex.raw(`CREATE OR REPLACE VIEW ${vue} AS 
+
+WITH
+    evenements_plus_recents AS (
+        SELECT DISTINCT ON (donnees ->> 'idService') id AS id_dernier_evenement
+        FROM journal_mss.vue_evenements_sans_services_supprimes
+        WHERE type = 'COMPLETUDE_SERVICE_MODIFIEE'
+        ORDER BY donnees ->> 'idService', date DESC
+    ),
+    details_statuts AS (
+        SELECT id AS id_completude,
+            details."idMesure" AS id_mesure,
+            details."statut"
+         FROM journal_mss.vue_evenements_sans_services_supprimes,
+              jsonb_to_recordset(donnees -> 'detailMesures') as details("idMesure" text, "statut" text)
+         WHERE type = 'COMPLETUDE_SERVICE_MODIFIEE'
+     )
+     
+SELECT id_mesure, statut, COUNT(*) as total
+FROM evenements_plus_recents recents
+JOIN details_statuts d ON recents.id_dernier_evenement = d.id_completude
+GROUP BY id_mesure, statut
+
+;`);
+
+exports.down = knex => knex.raw(`DROP VIEW IF EXISTS ${vue}`);

--- a/migrations/20230203152052_creationVueRepartitionPourcentageParStatutMesure.js
+++ b/migrations/20230203152052_creationVueRepartitionPourcentageParStatutMesure.js
@@ -1,0 +1,12 @@
+const vue = `journal_mss.vue_repartition_pourcentage_par_statut_mesure`;
+
+exports.up = knex => knex.raw(`CREATE OR REPLACE VIEW ${vue} AS 
+
+SELECT id_mesure,
+       statut,
+       ROUND(100 * (total / (sum(total) OVER (PARTITION BY id_mesure)))) as pourcentage
+FROM journal_mss.vue_statuts_mesures_personnalisees
+
+;`);
+
+exports.down = knex => knex.raw(`DROP VIEW IF EXISTS ${vue}`);


### PR DESCRIPTION
On veut montrer dans Metabase le pourcentage de « Fait / En cours / Non fait » par mesure.

Cette PR utilise les données mise à disposition par https://github.com/betagouv/mon-service-securise/pull/662.

Elle ajoute 2 vues SQL.

La première vue retourne le nombre de « Fait / En cours / Non fait » pour chaque mesure.
Une ligne par couple « Mesure / Statut » 👇 

![image](https://user-images.githubusercontent.com/24898521/216643738-c7616a68-fb6d-4986-882b-03d399b8745a.png)


La seconde vue utilise la première pour calculer un pourcentage de répartition par mesure 👇 

![image](https://user-images.githubusercontent.com/24898521/216644159-36643572-d417-4431-b7ad-06ef7c35dde8.png)


🔍 Par exemple pour `certificatChiffrement` on voit qu'on a `2 enCours` et `1 fait` ce qui nous donne respectivement `67%` et `33%`.

📊 Côté Metabase, c'est très simple il suffit de brancher une visualisation sur la seconde vue de cette PR 👇 

![image](https://user-images.githubusercontent.com/24898521/216644713-e8ee6515-6c73-4f1e-9e68-07fb7f2ff39b.png)
