### PR TITLE
Correction de la documentation et utilisateur Admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Paramétrer Metabase en suivant les instructions à l'écran :
  - Database name : `mss-journal`
  - Username : `metabase`
  - Password : laisser vide
- - Schemas : `Only these…` > `journal_mss`
+ - Schemas : `Only these…` > `journal_mss` (Attention ! C'est un `_`  et non un `-`)
 
 Vous êtes à présent prêt à [poser des questions Metabase](https://www.metabase.com/docs/latest/questions/start) sur les 
 données de MonServiceSécurisé.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,8 @@ services:
       - MB_DB_TYPE=postgres
       - MB_DB_DBNAME=mss-journal
       - MB_DB_PORT=5432
-      - MB_DB_USER=metabase
-      - MB_DB_PASS=
+      - MB_DB_USER=postgres
+      - MB_DB_PASS=postgres
       - MB_DB_HOST=mss-journal-db
     networks:
       - mss-network


### PR DESCRIPTION
Afin de créer les tables techniques dont il a besoin, Metabase doit utiliser un role Admin.