### PR TITLE
Création de vues de type « derniers en date »

### DIFF
--- a/migrations/20230327081756_creationVueEvenementsCompletudeServiceModifieeDerniersEnDate.js
+++ b/migrations/20230327081756_creationVueEvenementsCompletudeServiceModifieeDerniersEnDate.js
@@ -1,0 +1,18 @@
+const vue = `journal_mss.vue_evenements_completude_service_modifiee_derniers_en_date`;
+
+exports.up = knex => knex.raw(`CREATE OR REPLACE VIEW ${vue} AS 
+  
+WITH
+    derniers_en_date AS (
+        SELECT DISTINCT ON (donnees ->> 'idService') id AS id_dernier_evenement
+        FROM journal_mss.evenements
+        WHERE type = 'COMPLETUDE_SERVICE_MODIFIEE'
+        ORDER BY donnees ->> 'idService', date DESC
+    )
+SELECT e.*
+FROM journal_mss.evenements e
+JOIN derniers_en_date d on d.id_dernier_evenement = e.id
+
+;`);
+
+exports.down = knex => knex.raw(`DROP VIEW IF EXISTS ${vue};`)

--- a/migrations/20230327082622_creationVueEvenementsProfilUtilisateurModifieDerniersEnDate.js
+++ b/migrations/20230327082622_creationVueEvenementsProfilUtilisateurModifieDerniersEnDate.js
@@ -1,0 +1,18 @@
+const vue = `journal_mss.vue_evenements_profil_utilisateur_modifie_derniers_en_date`;
+
+exports.up = knex => knex.raw(`CREATE OR REPLACE VIEW ${vue} AS 
+  
+WITH
+    derniers_en_date AS (
+        SELECT DISTINCT ON (donnees ->> 'idUtilisateur') id AS id_dernier_evenement
+        FROM journal_mss.evenements
+        WHERE type = 'PROFIL_UTILISATEUR_MODIFIE'
+        ORDER BY donnees ->> 'idUtilisateur', date DESC
+    )
+SELECT e.*
+FROM journal_mss.evenements e
+JOIN derniers_en_date d on d.id_dernier_evenement = e.id
+
+;`);
+
+exports.down = knex => knex.raw(`DROP VIEW IF EXISTS ${vue};`)


### PR DESCRIPTION
Cette PR ajoute 2 vues qui montrent les « derniers événements en date » pour les modifications de service, et les modifications de profil utilisateur.

Maintenant qu'on utilise de plus en plus Metabase, on se rend compte que ce type de vue « derniers en date » est nécessaire pour créer facilement des visualisations pertinentes.