### PR TITLE
Création d'une archi de chargement de données 

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -1,0 +1,7 @@
+{
+  "jobs": [
+    {
+      "command": "*/10 * * * * psql -d $SCALINGO_POSTGRESQL_URL -c \"CALL journal_mss.charge_donnees()\""
+    }
+  ]
+}

--- a/migrations/20231014185419_creationTableDonneesCompletude.js
+++ b/migrations/20231014185419_creationTableDonneesCompletude.js
@@ -1,0 +1,14 @@
+exports.up = async (knex) =>
+    knex.schema
+        .withSchema('journal_mss')
+        .createTable('donnees_completude', table => {
+          table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+          table.timestamp('date');
+          table.text('id_service');
+          table.integer('nombre_total_mesures');
+          table.integer('nombre_mesures_completes');
+          table.float('taux_completude');
+          table.jsonb('donnees_origine');
+        })
+
+exports.down = async knex => knex.schema.dropTable('journal_mss.donnees_completude');

--- a/migrations/20231014193905_creationProcedureStockeeChargeDonnees.js
+++ b/migrations/20231014193905_creationProcedureStockeeChargeDonnees.js
@@ -1,0 +1,35 @@
+const procedureStockee = `journal_mss.charge_donnees()`;
+
+exports.up = knex => knex.raw(`
+
+CREATE OR REPLACE PROCEDURE ${procedureStockee}
+LANGUAGE SQL
+AS $$
+
+TRUNCATE TABLE journal_mss.donnees_completude;
+
+INSERT INTO journal_mss.donnees_completude (id_service,
+                                            nombre_total_mesures,
+                                            nombre_mesures_completes,
+                                            taux_completude,
+                                            date,
+                                            donnees_origine)
+SELECT distinct evenements.donnees ->> 'idService',
+                (first_value(donnees ->> 'nombreTotalMesures') over par_service_par_jour)::integer,
+                (first_value(donnees ->> 'nombreMesuresCompletes') over par_service_par_jour)::integer,
+                (first_value(donnees ->> 'nombreMesuresCompletes') over par_service_par_jour)::float
+                    / (first_value(donnees ->> 'nombreTotalMesures') over par_service_par_jour)::float,
+                first_value(date) over par_service_par_jour,
+                first_value(donnees) over par_service_par_jour
+FROM journal_mss.evenements
+WHERE evenements.type = 'COMPLETUDE_SERVICE_MODIFIEE'
+  and evenements.donnees ->> 'idService' not in
+      (select donnees ->> 'idService' from journal_mss.evenements where type = 'SERVICE_SUPPRIME')
+window par_service_par_jour as ( partition by evenements.donnees ->> 'idService', date::date order by date desc );
+
+$$;
+
+`);
+
+exports.down = knex => knex.raw(`DROP PROCEDURE IF EXISTS ${procedureStockee};`)
+


### PR DESCRIPTION
### Problème de performance
Pour exploiter Metabase efficacement, on veut des données plus précises que celles qui sont brutes dans la table `journal_mss.evenements`.

 💡 Une piste à explorer est d'avoir une série de table `donnees_…` qui contiennent des données métier à plat et non redondantes, prêtes à être exploitées par des modèles Metabase.

🔍  Voici une analyse sur les données de `COMPLETUDE_SERVICE_MODIFIEE` qui motive l'exploration de cette piste.
En PROD aujourd'hui on a :
 - 8 553 events de `COMPLETUDE`
 - mais **seulement** 3 757 events si on garde seulement le dernier event par service par jour

➡️ Donc on a seulement 44 % des lignes qui sont utiles.
➡️ Et tous nos modèles Metabase doivent faire ce travail de calcul de _« 1 ligne par jour et par service »_ à chaque utilisation.

🔴 On décide d'essayer d'optimiser tout ça.


### Cette PR 
 - Crée une table `journal_mss.donnees_completude` pour les données de complétude 
   - nombre de mesures avec statut, 
   - nombre de mesures totales, 
   - taux de complétude
 - Ajoute une procédure stockée qui `TRUNCATE` puis rempli cette table avec **1 ligne par service et par jour**
 - Ajoute un job `cron` pour que la procédure soit exécutée toutes les 10 minutes chez Scalingo