### PR TITLE
Éclate la procédure de chargement de données en plusieurs

### DIFF
--- a/migrations/20231024195801_creationProcedureStockeeChargeCompletude.js
+++ b/migrations/20231024195801_creationProcedureStockeeChargeCompletude.js
@@ -1,0 +1,33 @@
+exports.up = knex => knex.raw(`
+
+CREATE OR REPLACE PROCEDURE journal_mss.charge_donnees_completude()
+LANGUAGE SQL
+AS $$
+
+TRUNCATE TABLE journal_mss.donnees_completude;
+
+INSERT INTO journal_mss.donnees_completude (id_service,
+                                            nombre_total_mesures,
+                                            nombre_mesures_completes,
+                                            taux_completude,
+                                            date,
+                                            donnees_origine)
+SELECT DISTINCT evenements.donnees ->> 'idService',
+                (first_value(donnees ->> 'nombreTotalMesures') over par_service_par_jour)::integer,
+                (first_value(donnees ->> 'nombreMesuresCompletes') over par_service_par_jour)::integer,
+                (first_value(donnees ->> 'nombreMesuresCompletes') over par_service_par_jour)::float
+                    / (first_value(donnees ->> 'nombreTotalMesures') over par_service_par_jour)::float,
+                first_value(date) over par_service_par_jour,
+                first_value(donnees) over par_service_par_jour
+FROM journal_mss.evenements
+WHERE evenements.type = 'COMPLETUDE_SERVICE_MODIFIEE'
+  AND evenements.donnees ->> 'idService' NOT IN
+      (select donnees ->> 'idService' from journal_mss.evenements where type = 'SERVICE_SUPPRIME')
+WINDOW par_service_par_jour AS ( partition by evenements.donnees ->> 'idService', date::date order by date desc );
+
+$$;
+
+`);
+
+exports.down = knex => knex.raw(`DROP PROCEDURE IF EXISTS journal_mss.charge_donnees_completude();`)
+

--- a/migrations/20231024195909_creationTableLogChargementDonnees.js
+++ b/migrations/20231024195909_creationTableLogChargementDonnees.js
@@ -1,0 +1,11 @@
+exports.up = knex => {
+  return knex.schema
+      .withSchema('journal_mss')
+      .createTable('technique_chargement_donnees', table => {
+        table.timestamp('date_chargement').defaultTo(knex.raw('now()'));
+      })
+};
+
+exports.down = knex => {
+  return knex.schema.dropTable('journal_mss.technique_chargement_donnees')
+};

--- a/migrations/20231024200252_eclatementProcedureChargeDonnees.js
+++ b/migrations/20231024200252_eclatementProcedureChargeDonnees.js
@@ -1,0 +1,15 @@
+exports.up = knex => knex.raw(`
+
+CREATE OR REPLACE PROCEDURE journal_mss.charge_donnees()
+LANGUAGE SQL
+AS $$
+
+  CALL journal_mss.charge_donnees_completude();
+      
+  INSERT INTO journal_mss.technique_chargement_donnees(date_chargement) VALUES (now());
+      
+$$;
+
+`);
+
+exports.down = knex => knex.raw(`DROP PROCEDURE IF EXISTS journal_mss.charge_donnees();`)


### PR DESCRIPTION
On passe à une architecture où `journal_mss.charge_donnees()` appelle d'autres procédure filles, et finit par insérer une date d'exécution dans la table de log `journal_mss.technique_chargement_donnees`.

Ça va permettre de plus facilement augmenter les capacités de chargement de données en créant d'autres procédures filles.