### PR TITLE
Chargement des bornes basses et hautes du nombre d'entités utilisatrices d'un service

### DIFF
--- a/migrations/20231215135705_creationTableDonneesDescriptionService.js
+++ b/migrations/20231215135705_creationTableDonneesDescriptionService.js
@@ -1,0 +1,13 @@
+exports.up = async (knex) =>
+    knex.schema
+        .withSchema('journal_mss')
+        .createTable('donnees_description_service', table => {
+          table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+          table.timestamp('date');
+          table.text('id_service');
+          table.integer('nb_entites_utilisatrices_borne_basse');
+          table.integer('nb_entites_utilisatrices_borne_haute');
+          table.jsonb('donnees_origine');
+        })
+
+exports.down = async knex => knex.schema.dropTable('journal_mss.donnees_description_service');

--- a/migrations/20231215140432_creationProcedureStockeeChargeDescriptionService.js
+++ b/migrations/20231215140432_creationProcedureStockeeChargeDescriptionService.js
@@ -1,0 +1,32 @@
+exports.up = knex => knex.raw(`
+
+CREATE OR REPLACE PROCEDURE journal_mss.charge_donnees_description_service()
+LANGUAGE SQL
+AS $$
+
+TRUNCATE TABLE journal_mss.donnees_description_service;
+
+INSERT INTO journal_mss.donnees_description_service (id_service,
+                                            nb_entites_utilisatrices_borne_basse,
+                                            nb_entites_utilisatrices_borne_haute,
+                                            date,
+                                            donnees_origine)
+SELECT DISTINCT evenements.donnees ->> 'idService',
+                COALESCE((first_value(donnees -> 'nombreOrganisationsUtilisatrices' ->> 'borneBasse')
+                          over par_service_par_jour), '1')::integer,
+                COALESCE((first_value(donnees -> 'nombreOrganisationsUtilisatrices' ->> 'borneHaute')
+                          over par_service_par_jour), '1')::integer,
+                first_value(date) over par_service_par_jour,
+                first_value(donnees) over par_service_par_jour
+FROM journal_mss.evenements
+WHERE evenements.type = 'COMPLETUDE_SERVICE_MODIFIEE'
+  AND evenements.donnees ->> 'idService' NOT IN
+      (select donnees ->> 'idService' from journal_mss.evenements where type = 'SERVICE_SUPPRIME')
+WINDOW par_service_par_jour AS ( partition by evenements.donnees ->> 'idService', date::date order by date desc );
+
+$$;
+
+`);
+
+exports.down = knex => knex.raw(`DROP PROCEDURE IF EXISTS journal_mss.charge_donnees_description_service();`)
+

--- a/migrations/20231215142601_ajoutDescriptionServiceAuChargementDonnees.js
+++ b/migrations/20231215142601_ajoutDescriptionServiceAuChargementDonnees.js
@@ -1,0 +1,16 @@
+exports.up = knex => knex.raw(`
+
+CREATE OR REPLACE PROCEDURE journal_mss.charge_donnees()
+LANGUAGE SQL
+AS $$
+
+  CALL journal_mss.charge_donnees_completude();
+  CALL journal_mss.charge_donnees_description_service();
+      
+  INSERT INTO journal_mss.technique_chargement_donnees(date_chargement) VALUES (now());
+      
+$$;
+
+`);
+
+exports.down = knex => knex.raw(`DROP PROCEDURE IF EXISTS journal_mss.charge_donnees();`)


### PR DESCRIPTION
Depuis https://github.com/betagouv/mon-service-securise/pull/1199 on sait que MSS envoie `nombreOrganisationsUtilisatrices: { borneBasse, borneHaute }` dans les `donnees` de l'événement `COMPLETUDE_SERVICE_MODIFIEE`.

On veut pouvoir exploiter ces données dans Metabase.


Il nous faut donc (et c'est ce qu'ajoute cette PR) :
- Une nouvelle table pour stocker les données métier au format relationnel : `journal_mss.donnees_description_service`
- Une procédure stockée qui alimente cette table en utilisant les données des `evenements` : `charge_donnees_description_service()`
- Un appel à cette nouvelle procédure stockée depuis la procédure globale de chargement