### PR TITLE
Exploitation des données du collaboratif

### DIFF
--- a/migrations/20240220105728_creationTableDonneesCollaboratifService.js
+++ b/migrations/20240220105728_creationTableDonneesCollaboratifService.js
@@ -1,0 +1,14 @@
+exports.up = async knex =>
+    knex.schema
+        .withSchema('journal_mss')
+        .createTable('donnees_collaboratif_service', table => {
+          table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+          table.timestamp('date');
+          table.text('id_service');
+          table.text('id_utilisateur');
+          table.text('droit');
+          table.jsonb('donnees_origine');
+        })
+
+
+exports.down = async knex => knex.schema.dropTable('journal_mss.donnees_collaboratif_service');

--- a/migrations/20240220131152_creationProcedureStockeeChargeCollaboratifService.js
+++ b/migrations/20240220131152_creationProcedureStockeeChargeCollaboratifService.js
@@ -1,0 +1,38 @@
+exports.up = knex => knex.raw(`
+
+CREATE OR REPLACE PROCEDURE journal_mss.charge_donnees_collaboratif_service()
+LANGUAGE SQL
+AS $$
+
+    TRUNCATE TABLE journal_mss.donnees_collaboratif_service;
+    INSERT INTO journal_mss.donnees_collaboratif_service (
+                                                      id_service,
+                                                      id_utilisateur,
+                                                      droit,
+                                                      date,
+                                                      donnees_origine)
+    WITH autorisations_par_service AS (SELECT DISTINCT e.donnees ->> 'idService' as id_service,
+                                                   first_value(e.donnees -> 'autorisations') over par_service as autorisations,
+                                                   first_value(date) over par_service as date,
+                                                   first_value(e.donnees) over par_service as donnees_origine
+                                   FROM journal_mss.evenements as e
+                                   where e.type = 'COLLABORATIF_SERVICE_MODIFIE'
+                                     AND e.donnees ->> 'idService' NOT IN
+                                         (select donnees ->> 'idService'
+                                          from journal_mss.evenements
+                                          where type = 'SERVICE_SUPPRIME')
+                                   WINDOW par_service AS (partition by e.donnees ->> 'idService' order by date desc))
+    SELECT id_service,
+           une_autorisation ->> 'idUtilisateur' as id_utilisateur,
+           une_autorisation ->> 'droit'         as droit,
+           date,
+           donnees_origine
+    FROM autorisations_par_service
+             cross join lateral jsonb_array_elements(autorisations) as une_autorisation
+
+$$;
+
+`);
+
+exports.down = knex => knex.raw(`DROP PROCEDURE IF EXISTS journal_mss.charge_donnees_collaboratif_service();`)
+

--- a/migrations/20240220131934_ajoutCollaboratifServiceAuChargementDonnees.js
+++ b/migrations/20240220131934_ajoutCollaboratifServiceAuChargementDonnees.js
@@ -1,0 +1,18 @@
+exports.up = knex => knex.raw(`
+
+CREATE OR REPLACE PROCEDURE journal_mss.charge_donnees()
+LANGUAGE SQL
+AS $$
+
+  CALL journal_mss.charge_donnees_completude();
+  CALL journal_mss.charge_donnees_description_service();
+  CALL journal_mss.charge_donnees_collaboratif_service();
+  
+      
+  INSERT INTO journal_mss.technique_chargement_donnees(date_chargement) VALUES (now());
+      
+$$;
+
+`);
+
+exports.down = knex => knex.raw(`DROP PROCEDURE IF EXISTS journal_mss.charge_donnees();`)


### PR DESCRIPTION
Depuis peu MSS envoie des événements de type `COLLABORATIF_SERVICE_MODIFIE` contenant des données sur le collaboratif : combien de contributeurs, avec quels droits, etc…

Cette PR crée une table `journal_mss.donnees_collaboratif_service` destinée à contenir ces informations.

-------------

On respecte le pattern en place :

1. une table dédié
2. une procédure stockée de chargement
3. un appel à cette procédure depuis `journal_mss.charge_donnees()` qui coordonne le chargement