### PR TITLE
Supprime les informations de collectiviteTerritoriale des évènements ProfilUtilisateurModifié

### DIFF
--- a/migrations/20240415145858_supprimeCollectiviteTerritorialeDesEntitesDesEvenementsProfilUtilisateurModifie.js
+++ b/migrations/20240415145858_supprimeCollectiviteTerritorialeDesEntitesDesEvenementsProfilUtilisateurModifie.js
@@ -1,0 +1,4 @@
+exports.up = knex => knex.raw("update journal_mss.evenements SET donnees=donnees::jsonb #- '{entite,collectiviteTerritoriale}' where type = 'PROFIL_UTILISATEUR_MODIFIE';");
+
+exports.down = _ => {
+};


### PR DESCRIPTION
Cet objet contenant trop d'information permettant d'identifier l'entité de l'utilisateur