### PR TITLE
Ordonne de rebuilder dans le cas où le même commit est redéployé

### DIFF
--- a/.github/workflows/deploiement.yml
+++ b/.github/workflows/deploiement.yml
@@ -29,7 +29,7 @@ jobs:
           ID_ORGANISATION: ${{ secrets.CLEVER_CLOUD_ID_ORGANISATION }}
         run: |
           clever link -o="$ID_ORGANISATION" "$ID_APP"
-          clever deploy --force
+          clever deploy --force --same-commit-policy=rebuild
 
   deploiement-prod:
     needs: [deploiement-demo]
@@ -54,4 +54,4 @@ jobs:
           ID_ORGANISATION: ${{ secrets.CLEVER_CLOUD_ID_ORGANISATION }}
         run: |
           clever link -o="$ID_ORGANISATION" "$ID_APP"
-          clever deploy --force
+          clever deploy --force --same-commit-policy=rebuild


### PR DESCRIPTION
Utile si le déploiement a échoué et qu'on veut le relancer.