### PR TITLE
Ajout du chargement des données liées aux changements de statuts des mesures

### DIFF
--- a/migrations/20240906120107_creationTableDonneesStatutsDesMesures.js
+++ b/migrations/20240906120107_creationTableDonneesStatutsDesMesures.js
@@ -1,0 +1,14 @@
+const table = 'donnees_statuts_des_mesures';
+
+exports.up = async knex =>
+    knex.schema
+        .withSchema('journal_mss')
+        .createTable(table, table => {
+          table.text('id_service');
+          table.text('id_mesure');
+          table.text('statut');
+          table.timestamp('date');
+        })
+
+
+exports.down = async knex => knex.schema.dropTable(`journal_mss.${table}`);

--- a/migrations/20240906121239_creationProcedureStockeeChargeStatutsDesMesures.js
+++ b/migrations/20240906121239_creationProcedureStockeeChargeStatutsDesMesures.js
@@ -1,0 +1,35 @@
+exports.up = knex => knex.raw(`
+
+CREATE OR REPLACE PROCEDURE journal_mss.charge_donnees_statuts_des_mesures()
+LANGUAGE SQL
+AS $$
+
+    TRUNCATE TABLE journal_mss.donnees_statuts_des_mesures;
+    
+    INSERT INTO journal_mss.donnees_statuts_des_mesures (
+                                                      id_service,
+                                                      id_mesure,
+                                                      statut,
+                                                      date)
+        WITH tous_les_evenements AS (SELECT donnees ->> 'idService' AS id_service,
+                                            details."idMesure"      AS id_mesure,
+                                            details."statut",
+                                            date
+                                    FROM journal_mss.evenements,
+                                        jsonb_to_recordset(donnees -> 'detailMesures') AS details("idMesure" text,
+                                                                                                  "statut" text)
+                                    WHERE type = 'COMPLETUDE_SERVICE_MODIFIEE')
+        SELECT DISTINCT
+          id_service,
+          id_mesure,
+          statut,
+          first_value(date) over par_service_mesure_statut as date
+        FROM tous_les_evenements
+        WINDOW par_service_mesure_statut AS (partition by id_service, id_mesure, statut order by date);
+
+$$;
+
+`);
+
+exports.down = knex => knex.raw(`DROP PROCEDURE IF EXISTS journal_mss.charge_donnees_statuts_des_mesures();`)
+

--- a/migrations/20240906122546_ajouteStatutsDesMesuresAuChargementDonnees.js
+++ b/migrations/20240906122546_ajouteStatutsDesMesuresAuChargementDonnees.js
@@ -1,0 +1,22 @@
+exports.up = knex => knex.raw(`
+
+CREATE OR REPLACE PROCEDURE journal_mss.charge_donnees()
+LANGUAGE SQL
+AS $$
+
+  CALL journal_mss.charge_donnees_completude();
+  CALL journal_mss.charge_donnees_description_service();
+  CALL journal_mss.charge_donnees_collaboratif_service();
+  CALL journal_mss.charge_donnees_type_service();
+  CALL journal_mss.charge_donnees_fonctionnalite_service();
+  CALL journal_mss.charge_donnees_caractere_personnel_service();
+  CALL journal_mss.charge_donnees_statuts_des_mesures();
+  
+      
+  INSERT INTO journal_mss.technique_chargement_donnees(date_chargement) VALUES (now());
+      
+$$;
+
+`);
+
+exports.down = knex => knex.raw(`DROP PROCEDURE IF EXISTS journal_mss.charge_donnees();`)


### PR DESCRIPTION
Cette PR ajoute une table et une procédure stockée qui charge des données permettant de savoir à quelle date une mesure a changé de statut 👇 

![image](https://github.com/user-attachments/assets/fe34ce21-fae0-4785-8e13-a24fa379586a)

On récupère des données sans doublons, peu importe le nombre de `COMPLETUDE_SERVICE_MODIFIEE` qui arrive sur une journée pour un service.