### PR TITLE
Ajoute un index d'unicité sur la table de superviseurs

### DIFF
--- a/migrations/20241106154924_ajouteIndexSuperviseurs.js
+++ b/migrations/20241106154924_ajouteIndexSuperviseurs.js
@@ -1,0 +1,9 @@
+exports.up = async knex =>
+    knex.schema.alterTable('journal_mss.superviseurs', table => {
+        table.unique(['id_superviseur', 'id_service', 'siret_service']);
+    });
+
+exports.down = async knex =>
+    knex.schema.alterTable('journal_mss.superviseurs', table => {
+        table.dropUnique(['id_superviseur', 'id_service', 'siret_service'])
+    });


### PR DESCRIPTION
... afin de pouvoir réaliser des `upsert` et garantir qu'un service et supervisé par un superviseur une seule fois.