### PR TITLE
Optimisation du stockage de l'indice cyber courant dans metabase

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - /var/lib/postgresql/data
 
   metabase:
-    image: metabase/metabase
+    image: metabase/metabase:v0.51.3
     environment:
       - MB_DB_TYPE=postgres
       - MB_DB_DBNAME=mss-journal

--- a/migrations/20241119142142_creationTableDonneesIndiceCyberCourant.js
+++ b/migrations/20241119142142_creationTableDonneesIndiceCyberCourant.js
@@ -1,0 +1,14 @@
+exports.up = knex => knex.raw(`
+    CREATE TABLE IF NOT EXISTS journal_mss.donnees_indice_cyber_courant (
+        id UUID CONSTRAINT pk_donnees_indice_cyber_courant PRIMARY KEY DEFAULT gen_random_uuid(),
+        id_service VARCHAR(128) NOT NULL,
+        categorie VARCHAR(128) NOT NULL,
+        indice REAL NOT NULL,
+        date TIMESTAMP NOT NULL 
+    );
+`);
+
+exports.down = knex => knex.raw(`
+    DROP TABLE IF EXISTS journal_mss.donnees_indice_cyber_courant; 
+`)
+

--- a/migrations/20241119143802_creationProcedureStockeeChargeIndiceCyberCourant.js
+++ b/migrations/20241119143802_creationProcedureStockeeChargeIndiceCyberCourant.js
@@ -1,0 +1,27 @@
+exports.up = knex => knex.raw(`
+
+CREATE OR REPLACE PROCEDURE journal_mss.charge_donnees_indice_cyber_courant()
+LANGUAGE SQL
+AS $$
+      
+    TRUNCATE TABLE journal_mss.donnees_indice_cyber_courant;
+        
+    INSERT INTO journal_mss.donnees_indice_cyber_courant (id_service, categorie, indice, date) 
+    SELECT DISTINCT ON (donnees ->> 'idService', details.categorie) 
+        donnees->>'idService' as id_service,
+        details."categorie",
+        details."indice",
+        date
+    FROM journal_mss.vue_evenements_sans_services_supprimes,
+         jsonb_to_recordset(donnees -> 'detailIndiceCyber') as details("categorie" text, "indice" float)
+    WHERE type = 'COMPLETUDE_SERVICE_MODIFIEE'
+    ORDER BY donnees ->> 'idService', details.categorie, date DESC;
+
+$$;
+
+`);
+
+exports.down = knex => knex.raw(`
+    DROP PROCEDURE IF EXISTS journal_mss.charge_donnees_indice_cyber_courant();
+`)
+

--- a/migrations/20241119144706_ajouteIndiceCyberCourantAuChargementDonnees.js
+++ b/migrations/20241119144706_ajouteIndiceCyberCourantAuChargementDonnees.js
@@ -1,0 +1,24 @@
+exports.up = knex => knex.raw(`
+
+CREATE OR REPLACE PROCEDURE journal_mss.charge_donnees()
+LANGUAGE SQL
+AS $$
+
+  CALL journal_mss.charge_donnees_completude();
+  CALL journal_mss.charge_donnees_description_service();
+  CALL journal_mss.charge_donnees_collaboratif_service();
+  CALL journal_mss.charge_donnees_type_service();
+  CALL journal_mss.charge_donnees_fonctionnalite_service();
+  CALL journal_mss.charge_donnees_caractere_personnel_service();
+  CALL journal_mss.charge_donnees_statuts_des_mesures();
+  CALL journal_mss.charge_donnees_risques();
+  CALL journal_mss.charge_donnees_indice_cyber_courant();
+  
+      
+  INSERT INTO journal_mss.technique_chargement_donnees(date_chargement) VALUES (now());
+      
+$$;
+
+`);
+
+exports.down = knex => knex.raw(`DROP PROCEDURE IF EXISTS journal_mss.charge_donnees();`)


### PR DESCRIPTION
Cette PR stocke l'indice cyber courant de chaque service dans une table dédiée.
Ça permettra de créer des légo liés à l'indice cyber courant très rapides .