### PR TITLE
Remplace `charge_donnees` par des appels depuis le script shell

### DIFF
--- a/migrations/20241119151925_supprimeProcedureChargementDonnees.js
+++ b/migrations/20241119151925_supprimeProcedureChargementDonnees.js
@@ -1,0 +1,3 @@
+exports.up = knex => knex.raw(`DROP PROCEDURE IF EXISTS journal_mss.charge_donnees();`)
+
+exports.down = () => {}

--- a/scripts/execute_sql_charge_donnees.sh
+++ b/scripts/execute_sql_charge_donnees.sh
@@ -11,4 +11,18 @@ if [[ "$INSTANCE_NUMBER" != "0" ]]; then
   exit 0
 fi
 
-psql -d "$URL_SERVEUR_BASE_DONNEES" -c "CALL journal_mss.charge_donnees()"
+psql -d "$URL_SERVEUR_BASE_DONNEES" <<SQL
+
+  CALL journal_mss.charge_donnees_completude();
+  CALL journal_mss.charge_donnees_description_service();
+  CALL journal_mss.charge_donnees_collaboratif_service();
+  CALL journal_mss.charge_donnees_type_service();
+  CALL journal_mss.charge_donnees_fonctionnalite_service();
+  CALL journal_mss.charge_donnees_caractere_personnel_service();
+  CALL journal_mss.charge_donnees_statuts_des_mesures();
+  CALL journal_mss.charge_donnees_risques();
+  CALL journal_mss.charge_donnees_indice_cyber_courant();
+
+  INSERT INTO journal_mss.technique_chargement_donnees(date_chargement) VALUES (now());
+
+SQL


### PR DESCRIPTION
Ça nous évite de devoir sans cesse empiler des migrations qui modifient `charge_donnees` à chaque fois qu'une nouvelle procédure stockée enfant apparaît.