### PR TITLE
Crée le chargement de l'indice cyber hebdomadaire

### DIFF
--- a/migrations/20241125125218_creationTableDonneesIndiceCyberHebdomadaire.js
+++ b/migrations/20241125125218_creationTableDonneesIndiceCyberHebdomadaire.js
@@ -1,0 +1,12 @@
+exports.up = knex => knex.raw(`
+    CREATE TABLE IF NOT EXISTS journal_mss.donnees_indice_cyber_hebdomadaire (
+        id UUID CONSTRAINT pk_donnees_indice_cyber_hebdomadaire PRIMARY KEY DEFAULT gen_random_uuid(),
+        id_service VARCHAR(128) NOT NULL,
+        indice REAL NOT NULL,
+        date TIMESTAMP NOT NULL 
+    );
+`);
+
+exports.down = knex => knex.raw(`
+    DROP TABLE IF EXISTS journal_mss.donnees_indice_cyber_hebdomadaire; 
+`);

--- a/migrations/20241125125513_creationProcedureStockeeChargeIndiceCyberHebdomadaire.js
+++ b/migrations/20241125125513_creationProcedureStockeeChargeIndiceCyberHebdomadaire.js
@@ -1,0 +1,29 @@
+exports.up = knex => knex.raw(`
+
+CREATE OR REPLACE PROCEDURE journal_mss.charge_donnees_indice_cyber_hebdomadaire()
+LANGUAGE SQL
+AS $$
+      
+    TRUNCATE TABLE journal_mss.donnees_indice_cyber_hebdomadaire;
+        
+    INSERT INTO journal_mss.donnees_indice_cyber_hebdomadaire (id_service, indice, date)
+    SELECT DISTINCT
+        first_value(e.donnees ->> 'idService') over par_service_par_semaine as id_service,
+        first_value(details."indice") over par_service_par_semaine as indice,
+        first_value(e.date) over par_service_par_semaine as la_date
+    FROM journal_mss.vue_evenements_sans_services_supprimes e,
+         jsonb_to_recordset(donnees -> 'detailIndiceCyber') as details("categorie" text, "indice" float)
+    WHERE type = 'COMPLETUDE_SERVICE_MODIFIEE'
+      AND details.categorie = 'total'
+    WINDOW par_service_par_semaine AS (
+        PARTITION BY e.donnees ->> 'idService', extract(year from e.date), extract(week from e.date)
+        ORDER BY e.date DESC);
+
+$$;
+
+`);
+
+exports.down = knex => knex.raw(`
+    DROP PROCEDURE IF EXISTS journal_mss.charge_donnees_indice_cyber_hebdomadaire();
+`)
+

--- a/scripts/execute_sql_charge_donnees.sh
+++ b/scripts/execute_sql_charge_donnees.sh
@@ -22,6 +22,7 @@ psql -d "$URL_SERVEUR_BASE_DONNEES" <<SQL
   CALL journal_mss.charge_donnees_statuts_des_mesures();
   CALL journal_mss.charge_donnees_risques();
   CALL journal_mss.charge_donnees_indice_cyber_courant();
+  CALL journal_mss.charge_donnees_indice_cyber_hebdomadaire();
 
   INSERT INTO journal_mss.technique_chargement_donnees(date_chargement) VALUES (now());
 


### PR DESCRIPTION
On va stocker, pour chaque service, les valeurs de son indice cyber à la maille de la semaine.
C'est un échantillonnage qui permettra de produire des données d'évolution d'indice cyber dans Metabase.