### PR TITLE
Stockage des données de complétude liées au premier passage au-delà de 80 %

### DIFF
--- a/migrations/20241210150754_creationTableDonneesCompletudePremiereFois80.js
+++ b/migrations/20241210150754_creationTableDonneesCompletudePremiereFois80.js
@@ -1,0 +1,15 @@
+exports.up = knex => knex.raw(`
+    CREATE TABLE IF NOT EXISTS journal_mss.donnees_completude_premiere_fois_80 (
+        id UUID CONSTRAINT pk_donnees_completude_premiere_fois_80 PRIMARY KEY DEFAULT gen_random_uuid(),
+        id_service VARCHAR(128) NOT NULL,
+        pourcentage_completion REAL NOT NULL,
+        nombre_mesures_completes INT NOT NULL,
+        nombre_total_mesures INT NOT NULL,
+        indice_cyber REAL NOT NULL,
+        date TIMESTAMP NOT NULL 
+    );
+`);
+
+exports.down = knex => knex.raw(`
+    DROP TABLE IF EXISTS journal_mss.donnees_completude_premiere_fois_80; 
+`);

--- a/migrations/20241210151552_creationProcedureStockeeChargeCompletudePremiereFois80.js
+++ b/migrations/20241210151552_creationProcedureStockeeChargeCompletudePremiereFois80.js
@@ -1,0 +1,46 @@
+exports.up = knex => knex.raw(`
+
+CREATE OR REPLACE PROCEDURE journal_mss.charge_donnees_completude_premiere_fois_80()
+LANGUAGE SQL
+AS $$
+      
+    TRUNCATE TABLE journal_mss.donnees_completude_premiere_fois_80;
+        
+    INSERT INTO journal_mss.donnees_completude_premiere_fois_80 (id_service, pourcentage_completion, nombre_mesures_completes, nombre_total_mesures, indice_cyber, date)
+    WITH
+    tout_sauf_indice AS (
+        SELECT DISTINCT
+            first_value(id) over par_service as id_evenement,
+            first_value(id_service) over par_service as id_service,
+            (first_value(taux_completude) over par_service) * 100 as pourcentage_completion,
+            first_value(nombre_mesures_completes) over par_service as nombre_mesures_completes,
+            first_value(nombre_total_mesures) over par_service as nombre_total_mesures,
+            first_value(date) over par_service as date
+        FROM journal_mss.donnees_completude c
+        WHERE taux_completude >= 0.8
+        AND date > '2023-02-14' -- date à partir de laquelle on monitore l'indice cyber dans Metabase
+        WINDOW par_service AS (PARTITION BY c.id_service ORDER BY date)
+    ),
+    indice AS (
+        SELECT id as id_evenement, indice as indice_cyber
+        FROM journal_mss.donnees_completude c,
+         jsonb_to_recordset(donnees_origine->'detailIndiceCyber') as x(categorie text, indice float)
+        WHERE categorie = 'total'
+    )
+    SELECT
+        a.id_service,
+        a.pourcentage_completion,
+        a.nombre_mesures_completes,
+        a.nombre_total_mesures,
+        b.indice_cyber,
+        a.date
+    FROM tout_sauf_indice a JOIN indice b on a.id_evenement = b.id_evenement
+    
+$$;
+
+`);
+
+exports.down = knex => knex.raw(`
+    DROP PROCEDURE IF EXISTS journal_mss.charge_donnees_completude_premiere_fois_80();
+`)
+

--- a/scripts/execute_sql_charge_donnees.sh
+++ b/scripts/execute_sql_charge_donnees.sh
@@ -23,6 +23,7 @@ psql -d "$URL_SERVEUR_BASE_DONNEES" <<SQL
   CALL journal_mss.charge_donnees_risques();
   CALL journal_mss.charge_donnees_indice_cyber_courant();
   CALL journal_mss.charge_donnees_indice_cyber_hebdomadaire();
+  CALL journal_mss.charge_donnees_completude_premiere_fois_80();
 
   INSERT INTO journal_mss.technique_chargement_donnees(date_chargement) VALUES (now());
 


### PR DESCRIPTION
En stockant ces données, on accélérera les calculs liés aux évolutions de l'indice cyber.