### PR TITLE
Nettoyage d'information dans les évènements

### DIFF
--- a/migrations/20250519090814_supprimeDonneesEntiteDesEvenementsProfilUtilisateurModifie.js
+++ b/migrations/20250519090814_supprimeDonneesEntiteDesEvenementsProfilUtilisateurModifie.js
@@ -1,0 +1,4 @@
+exports.up = knex => knex.raw("update journal_mss.evenements SET donnees=donnees::jsonb #- '{entite}' where type = 'PROFIL_UTILISATEUR_MODIFIE';");
+
+exports.down = _ => {
+};

--- a/migrations/20250519094725_supprimeDonneesOrganisationResponsableDesEvenementsCompletudeServiceModifie.js
+++ b/migrations/20250519094725_supprimeDonneesOrganisationResponsableDesEvenementsCompletudeServiceModifie.js
@@ -1,0 +1,4 @@
+exports.up = knex => knex.raw("update journal_mss.evenements SET donnees=donnees::jsonb #- '{organisationResponsable}' where type = 'COMPLETUDE_SERVICE_MODIFIEE';");
+
+exports.down = _ => {
+};


### PR DESCRIPTION
On n'utilise pas les données de l'organisation responsable (ou de l'entité) qui sont poussées dans les évènements `COMPLETUDE_SERVICE_MODIFIEE` et `PROFIL_UTILISATEUR_MODIFIE`. On supprime donc ces données de la base:

Donnees → OrganisationResponsable
Donnees → Entite

Cf. https://github.com/betagouv/mon-service-securise/pull/2177