### PR TITLE
Espace les chargements de 30 minutes

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -1,3 +1,3 @@
 [
-  "*/10 * * * * $ROOT/scripts/execute_sql_charge_donnees.sh"
+  "*/30 * * * * $ROOT/scripts/execute_sql_charge_donnees.sh"
 ]


### PR DESCRIPTION
… pour éviter qu'un chargement démarre pendant que le précédent est encore en cours. On commence par espacer davantage… ensuite, on optimisera si besoin.