### PR TITLE
Ajoute la machinerie pour charger les risques v2

### DIFF
--- a/migrations/20260626151540_creationTableDonneesRisquesV2Service.js
+++ b/migrations/20260626151540_creationTableDonneesRisquesV2Service.js
@@ -1,0 +1,17 @@
+exports.up = async knex =>
+    knex.schema
+        .withSchema('journal_mss')
+        .createTable('donnees_risques_v2_service', table => {
+            table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+            table.text('id_service').notNullable();
+            table.text('id_risque').notNullable();
+            table.text('type_risque').notNullable();
+            table.boolean('risque_desactive').notNullable();
+            table.boolean('risque_avec_commentaire').notNullable();
+            table.integer('risque_gravitee_initiale').notNullable();
+            table.integer('risque_gravitee_surchargee').nullable();
+        });
+
+
+exports.down = async knex =>
+    knex.schema.dropTable('journal_mss.donnees_risques_v2_service');

--- a/procedures_stockees/charge_donnees_risques_v2.sql
+++ b/procedures_stockees/charge_donnees_risques_v2.sql
@@ -1,0 +1,66 @@
+CREATE OR REPLACE PROCEDURE journal_mss.charge_donnees_risques_v2()
+LANGUAGE SQL
+AS
+$$
+
+TRUNCATE TABLE journal_mss.donnees_risques_v2_service;
+
+-- Insertion des risques généraux du dernier événement de chaque service
+INSERT INTO journal_mss.donnees_risques_v2_service (
+    id_service,
+    id_risque,
+    type_risque,
+    risque_desactive,
+    risque_avec_commentaire,
+    risque_gravitee_surchargee,
+    risque_gravitee_initiale)
+WITH dernier_evenement_par_service AS (
+    SELECT DISTINCT ON (donnees ->> 'idService')
+        donnees ->> 'idService' AS id_service,
+        donnees
+    FROM journal_mss.vue_evenements_sans_services_supprimes
+    WHERE type = 'RISQUES_V2_SERVICE_MODIFIES'
+    ORDER BY donnees ->> 'idService', date DESC
+)
+SELECT
+    e.id_service,
+    rg."id",
+    'general',
+    rg."desactive",
+    rg."avecCommentaire",
+    rg."valeurGraviteSurchargee",
+    rg."valeurGraviteCalculee"
+FROM dernier_evenement_par_service e,
+    jsonb_to_recordset(e.donnees -> 'risquesGeneraux')
+        AS rg("id" text, "desactive" boolean, "avecCommentaire" boolean, "valeurGraviteCalculee" integer, "valeurGraviteSurchargee" integer);
+
+-- Insertion des risques spécifiques du dernier événement de chaque service
+INSERT INTO journal_mss.donnees_risques_v2_service (
+    id_service,
+    id_risque,
+    type_risque,
+    risque_desactive,
+    risque_avec_commentaire,
+    risque_gravitee_surchargee,
+    risque_gravitee_initiale)
+WITH dernier_evenement_par_service AS (
+    SELECT DISTINCT ON (donnees ->> 'idService')
+        donnees ->> 'idService' AS id_service,
+        donnees
+    FROM journal_mss.vue_evenements_sans_services_supprimes
+    WHERE type = 'RISQUES_V2_SERVICE_MODIFIES'
+    ORDER BY donnees ->> 'idService', date DESC
+)
+SELECT
+    e.id_service,
+    rs."id",
+    'specifique',
+    false,
+    rs."avecCommentaire",
+    rs."valeurGravite",
+    rs."valeurGraviteBrute"
+FROM dernier_evenement_par_service e,
+    jsonb_to_recordset(e.donnees -> 'risquesSpecifiques')
+        AS rs("id" text, "avecCommentaire" boolean, "valeurGravite" integer, "valeurGraviteBrute" integer);
+
+$$;

--- a/scripts/execute_sql_charge_donnees.sh
+++ b/scripts/execute_sql_charge_donnees.sh
@@ -27,6 +27,7 @@ cat <<SQL | xargs -I {sql} psql -d "$URL_SERVEUR_BASE_DONNEES" -c "{sql}"
   CALL journal_mss.charge_donnees_categorie_donnees_traitees_service_v2();
   CALL journal_mss.charge_donnees_statuts_des_mesures();
   CALL journal_mss.charge_donnees_risques();
+  CALL journal_mss.charge_donnees_risques_v2();
   CALL journal_mss.charge_donnees_indice_cyber_courant();
   CALL journal_mss.charge_donnees_indice_cyber_hebdomadaire();
   CALL journal_mss.charge_donnees_indice_cyber_tous_les_vendredis_sample_and_hold();


### PR DESCRIPTION
On reste sur l'architecture en place : table + proc stock + exécution dans le cron.

Avec cette PR, et https://github.com/betagouv/mon-service-securise/pull/2937, alors on obtient dans le journal des données de la forme 👇 

<img width="800" alt="image" src="https://github.com/user-attachments/assets/280a30df-75b5-4819-9ee2-858c3c8331ed" />
